### PR TITLE
add build stages to install deps first

### DIFF
--- a/raw/Dockerfile
+++ b/raw/Dockerfile
@@ -13,9 +13,14 @@ ENV PATH="/root/.local/bin:$PATH"
 # No log buffering
 ENV PYTHONUNBUFFERED=1
 
-COPY . ./service
-
 WORKDIR /app/service
+
+COPY ./pyproject.toml .
+
+RUN uv pip compile pyproject.toml -o requirements.txt
+RUN uv pip install --system -r requirements.txt
+
+COPY . /app/service
 
 RUN uv pip install --system .
 


### PR DESCRIPTION
This pull request updates the `raw/Dockerfile` to improve Python dependency management and the build process. The main changes focus on using `uv` for compiling and installing dependencies from `pyproject.toml`, which streamlines dependency handling and ensures a cleaner build.

**Dependency management and build process improvements:**

* Added steps to copy `pyproject.toml` and use `uv pip compile` to generate a `requirements.txt` file, followed by installing dependencies with `uv pip install` before copying the rest of the service files.
* Changed the order of file copying and installation commands to ensure dependencies are installed before the application code is copied, reducing the likelihood of unnecessary rebuilds and improving Docker layer caching.